### PR TITLE
Hemant/variants on plp

### DIFF
--- a/src/Components/ProductCard/index.js
+++ b/src/Components/ProductCard/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
@@ -7,10 +9,20 @@ import './style.scss';
 
 const ProductCard = ({ product, className }) => {
   const navigate = useNavigate()
+  const [selectedVariant, setSelectedVariant] = useState(false);
+
   const onClick = () => {
     sessionStorage.productDetails = JSON.stringify(product);
     navigate(`/product-details?product=${product.productID}`);
   }
+
+  const productVariants = product.variants;
+  const maxVariantsToShow = 5;
+
+  useEffect(() => {
+    setSelectedVariant(productVariants[0])
+  }, [])
+
   return (
     <div className={classnames("product-card d-flex flex-md-column", className)}>
       <div onClick={onClick} className="product-card_img-wrapper overflow-hidden rounded-2">

--- a/src/Components/ProductCard/index.js
+++ b/src/Components/ProductCard/index.js
@@ -28,8 +28,29 @@ const ProductCard = ({ product, className }) => {
       <div onClick={onClick} className="product-card_img-wrapper overflow-hidden rounded-2">
         <img src={product.images[0].src} alt="product" />
       </div>
-      <div className="d-flex flex-column product-card_details ms-2">
-        <span className="fw-bolder mb-2" onClick={onClick}>
+      {productVariants.length > 1 ?
+        <div className="product-card_variants">
+          {productVariants.slice(0, maxVariantsToShow).map((variant, i) => (
+            <div
+              className={selectedVariant.title == variant.title ? "active" : ""}
+              style={{ backgroundImage: !!variant?.image && !!variant?.image?.src ? `url(${variant?.image?.src})` : "" }}
+              onClick={() => {
+                setSelectedVariant(variant)
+              }}
+            ></div>
+          ))}
+          {productVariants.length > maxVariantsToShow
+            ? <div
+                className="more-items"
+                onClick={onClick}
+              >{'+' + (productVariants.length - maxVariantsToShow)}</div>
+            : ''
+          }
+        </div>
+        : ""
+      }
+      <div onClick={onClick} className="d-flex flex-column product-card_details ms-2">
+        <span className="fw-bolder mb-2">
           {moneyFormatter(product.maxPrice, product.currencyCode)}
         </span>
         <span onClick={onClick} className="product-card_title mb-2 fw-600 text-light-primary">{product.title}</span>

--- a/src/Components/ProductCard/index.js
+++ b/src/Components/ProductCard/index.js
@@ -31,7 +31,7 @@ const ProductCard = ({ product, className }) => {
 
   const selectColorOption = colorOptionValue => {
     setSelectedColor(colorOptionValue);
-    if(!!colorOptionValue) {
+    if(colorOptionValue) {
       const selectableVariant = getSelectableVariantByColorOption(colorOptionValue);
       setSelectedVariant(selectableVariant)
     }
@@ -51,7 +51,7 @@ const ProductCard = ({ product, className }) => {
         <div className="product-card_variants">
           {getColorOptions()/*.slice(0, maxColorOptionsToShow)*/.map((colorOption, i) => (
             <div
-              className={selectedColor == colorOption ? "active" : ""}
+              className={selectedColor === colorOption ? "active" : ""}
               style={{ backgroundImage: `url(${getSelectableVariantByColorOption(colorOption)?.image?.src})` }}
               onClick={() => {
                 selectColorOption(colorOption)

--- a/src/Components/ProductCard/index.js
+++ b/src/Components/ProductCard/index.js
@@ -10,17 +10,36 @@ import './style.scss';
 const ProductCard = ({ product, className }) => {
   const navigate = useNavigate()
   const [selectedVariant, setSelectedVariant] = useState(false);
+  const [selectedColor, setSelectedColor] = useState(false)
 
   const onClick = () => {
     sessionStorage.productDetails = JSON.stringify(product);
     navigate(`/product-details?product=${product.productID}`);
   }
 
-  const productVariants = product.variants;
-  const maxVariantsToShow = 5;
+  const colorMetaName = 'Color';
+  const maxColorOptionsToShow = 5;
+
+  const getColorOptions = () => {
+    const colorOptions = product?.meta_data.filter(md => md.key === colorMetaName);
+    return !!colorOptions && !!colorOptions[0] ? colorOptions[0].values : false;
+  }
+
+  const getSelectableVariantByColorOption = colorOptionValue => {
+    return product?.variants.find(variant => variant.meta_data.find(md => md.key === colorMetaName && md.value === colorOptionValue))
+  }
+
+  const selectColorOption = colorOptionValue => {
+    setSelectedColor(colorOptionValue);
+    if(!!colorOptionValue) {
+      const selectableVariant = getSelectableVariantByColorOption(colorOptionValue);
+      setSelectedVariant(selectableVariant)
+    }
+  }
 
   useEffect(() => {
-    setSelectedVariant(productVariants[0])
+    const colorOptions = getColorOptions();
+    selectColorOption(!!colorOptions ? colorOptions[0] : false)
   }, [])
 
   return (
@@ -28,22 +47,22 @@ const ProductCard = ({ product, className }) => {
       <div onClick={onClick} className="product-card_img-wrapper overflow-hidden rounded-2">
         <img src={product.images[0].src} alt="product" />
       </div>
-      {productVariants.length > 1 ?
+      {product.variants.length > 1 && getColorOptions() ?
         <div className="product-card_variants">
-          {productVariants.slice(0, maxVariantsToShow).map((variant, i) => (
+          {getColorOptions()/*.slice(0, maxColorOptionsToShow)*/.map((colorOption, i) => (
             <div
-              className={selectedVariant.title == variant.title ? "active" : ""}
-              style={{ backgroundImage: !!variant?.image && !!variant?.image?.src ? `url(${variant?.image?.src})` : "" }}
+              className={selectedColor == colorOption ? "active" : ""}
+              style={{ backgroundImage: `url(${getSelectableVariantByColorOption(colorOption)?.image?.src})` }}
               onClick={() => {
-                setSelectedVariant(variant)
+                selectColorOption(colorOption)
               }}
             ></div>
           ))}
-          {productVariants.length > maxVariantsToShow
+          {getColorOptions().length > maxColorOptionsToShow
             ? <div
                 className="more-items"
                 onClick={onClick}
-              >{'+' + (productVariants.length - maxVariantsToShow)}</div>
+              >{'+' + (getColorOptions().length - maxColorOptionsToShow)}</div>
             : ''
           }
         </div>

--- a/src/Components/ProductCard/index.js
+++ b/src/Components/ProductCard/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { useState, useEffect } from 'react';
 import classnames from 'classnames';
-import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 
 import moneyFormatter from '../../utilities/moneyFormatter';
@@ -17,16 +16,19 @@ const ProductCard = ({ product, className }) => {
     navigate(`/product-details?product=${product.productID}`);
   }
 
-  const colorMetaName = 'Color';
+  const colorMetaNameRegex = new RegExp('^colou*r$', 'i');
   const maxColorOptionsToShow = 5;
 
   const getColorOptions = () => {
-    const colorOptions = product?.meta_data.filter(md => md.key === colorMetaName);
+    const colorOptions = product?.meta_data.filter(md => colorMetaNameRegex.test(md.key));
     return !!colorOptions && !!colorOptions[0] ? colorOptions[0].values : false;
   }
 
   const getSelectableVariantByColorOption = colorOptionValue => {
-    return product?.variants.find(variant => variant.meta_data.find(md => md.key === colorMetaName && md.value === colorOptionValue))
+    return product?.variants
+    .find(variant => variant.meta_data
+      .find(md => colorMetaNameRegex
+        .test(md.key) && md.value === colorOptionValue))
   }
 
   const selectColorOption = colorOptionValue => {
@@ -45,7 +47,7 @@ const ProductCard = ({ product, className }) => {
   return (
     <div className={classnames("product-card d-flex flex-md-column", className)}>
       <div onClick={onClick} className="product-card_img-wrapper overflow-hidden rounded-2">
-        <img src={product.images[0].src} alt="product" />
+        <img src={!!selectedVariant && !!selectedVariant?.image?.src ? selectedVariant?.image?.src : product.images[0].src} alt="product" />
       </div>
       {product.variants.length > 1 && getColorOptions() ?
         <div className="product-card_variants">

--- a/src/Components/ProductCard/style.scss
+++ b/src/Components/ProductCard/style.scss
@@ -27,4 +27,30 @@
     }
     width: unset;
   }
+  .product-card_variants {
+    display: flex;
+    justify-content: center;
+    padding: 10px 0;
+
+    div {
+      background: #CCC none center center / cover no-repeat;
+      border-radius: 50%;
+      font-size: 0;
+      height: 16px;
+      margin: 0 5px;
+      width: 16px;
+
+      &.active {
+        outline: 1px solid #17172C;
+      }
+
+      &.more-items {
+        background: transparent none;
+        border: 0;
+        font-size: 12px;
+        line-height: 16px;
+        text-decoration: underline;
+      }
+    }
+  }
 }


### PR DESCRIPTION
@Nziranziza and @achportfolio - Please review the display of variants on PLP.

The code looks for meta_data key `Color` in the product data in order to display Color options on PLP.

Products bearing more than one color options will be displayed:

![image](https://user-images.githubusercontent.com/101239948/164179826-746d69ac-cb66-4ec5-b6ed-5e8152f9cb36.png)

_This screenshot is a temporary representation and the "Disney Pixar Cars Jackson Storm 20 Inch Vehicle" product has Size and Material options. In order to test, please make sure the product in question has option (meta_data) key as "Color"._

Let me know your views. Thank you!